### PR TITLE
Guard against missing currentGallery element

### DIFF
--- a/src/baguetteBox.js
+++ b/src/baguetteBox.js
@@ -483,9 +483,16 @@
             }
             return;
         }
-
+        
+        var galleryItem = currentGallery[index];
+        // It's possible that the decision to preload is made,
+        // but by the time the load happens, the element is gone.
+        if (typeof galleryItem  === 'undefined') {
+            return;
+        }
+        
         // Get element reference, optional caption and source path
-        var imageElement = currentGallery[index].imageElement;
+        var imageElement = galleryItem.imageElement;
         var thumbnailElement = imageElement.getElementsByTagName('img')[0];
         var imageCaption = typeof options.captions === 'function' ?
                             options.captions.call(currentGallery, imageElement) :


### PR DESCRIPTION
When an image is loaded,
it can preload the next/previous image with a callback.
It's possible that between when the decision to preload is made
and the `loadImage` call for preloading happens,
the current gallery has been modified and the index to preload
is missing, causing the preload callback to error.
